### PR TITLE
Improve merge commits

### DIFF
--- a/bin/phraseapp_updater
+++ b/bin/phraseapp_updater
@@ -48,7 +48,7 @@ class PhraseAppUpdaterCLI < Thor
     ENV['FILE_FORMAT'] = options[:file_format]
     ENV['NO_COMMIT']   = options[:no_commit] ? 't' : 'f'
     ENV['PREFIX']      = options[:prefix]
-    ENV['BRANCH']      = options.fetch(:branch) { sh('git name-rev --name-only HEAD').chomp }
+    ENV['BRANCH']      = options.fetch(:branch) { sh('git rev-parse --abbrev-ref HEAD').chomp }
     ENV['REMOTE']      = options.fetch(:remote) { sh("git config branch.#{ENV['BRANCH']}.remote").chomp }
 
     shell_script_path = File.join(__dir__, 'synchronize_phraseapp.sh')

--- a/bin/synchronize_phraseapp.sh
+++ b/bin/synchronize_phraseapp.sh
@@ -78,9 +78,11 @@ if [ "${phraseapp_changed}" = 't' ] && [ "${branch_changed}" = 't' ]; then
 
     if [ "$NO_COMMIT" != 't' ]; then
         # Create a commit to record the pre-merge state of PhraseApp
-        phraseapp_commit=$(git commit-tree "${current_phraseapp_tree}" \
+        phraseapp_commit_tree=$(replace_nested_tree "${common_ancestor}^{tree}" "${PREFIX}" "${current_phraseapp_tree}")
+        phraseapp_commit=$(git commit-tree "${phraseapp_commit_tree}" \
                                -p "${common_ancestor}" \
-                               -m "Remote locale changes made on PhraseApp (drop when rebasing)")
+                               -m "Remote locale changes made on PhraseApp" \
+                               -m "These changes may be safely flattened into their merge commit when rebasing.")
 
         # Commit merge result to PREFIX in BRANCH
         merge_resolution_tree=$(make_tree_from_directory "${merge_resolution_path}")

--- a/bin/synchronize_phraseapp.sh
+++ b/bin/synchronize_phraseapp.sh
@@ -91,7 +91,8 @@ if [ "${phraseapp_changed}" = 't' ] && [ "${branch_changed}" = 't' ]; then
         merge_commit=$(git commit-tree "${merged_branch_tree}" \
                            -p "${current_branch}" \
                            -p "${phraseapp_commit}" \
-                           -m "Merged locale changes from PhraseApp")
+                           -m "Merged locale changes from PhraseApp" \
+                           -m "X-PhraseApp-Merge: ${phraseapp_commit}")
 
         # Push to BRANCH
         git push "${REMOTE}" "${merge_commit}:refs/heads/${BRANCH}"

--- a/lib/phraseapp_updater/version.rb
+++ b/lib/phraseapp_updater/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class PhraseAppUpdater
-  VERSION = "2.0.0"
+  VERSION = "2.0.1"
 end


### PR DESCRIPTION
Now that PhraseApp isn't being maintained as its own independent branch, it's clearer to mark the changes in the regular project tree, rather than as an extracted locales directory: git will actually be able to see and compare the changes.