### PR TITLE
Match local branch when synchronizing.

### DIFF
--- a/bin/synchronize_phraseapp.sh
+++ b/bin/synchronize_phraseapp.sh
@@ -25,6 +25,14 @@ git fetch "${REMOTE}"
 
 current_branch=$(git rev-parse "${REMOTE}/${BRANCH}")
 
+# If there's a local checkout of that branch, for safety's sake make sure that
+# it's up to date with the remote one.
+local_branch=$(git rev-parse "${BRANCH}")
+if [ "$local_branch" ] && [ "$current_branch" != "$local_branch" ]; then
+   echo "Error: local branch '${BRANCH}' exists but does not match '${REMOTE}/${BRANCH}'." >&2
+   exit 1
+fi
+
 # First, fetch the current contents of PhraseApp's staged ("verified") state.
 current_phraseapp_path=$(make_temporary_directory)
 common_ancestor=$(phraseapp_updater download "${current_phraseapp_path}" \

--- a/lib/phraseapp_updater/version.rb
+++ b/lib/phraseapp_updater/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class PhraseAppUpdater
-  VERSION = '2.0.5'
+  VERSION = '2.0.6'
 end


### PR DESCRIPTION
If a local branch exists when synchronizing, ensure that it matches the remote
branch that will be operated on. This improves safety in the case that there are
important unpushed local changes or rebases.