### PR TITLE
Allow passing of properties to the phraseapp API that are allowed

### DIFF
--- a/bin/phraseapp_updater
+++ b/bin/phraseapp_updater
@@ -16,16 +16,47 @@ class PhraseAppUpdaterCLI < Thor
   method_option :parent_commit,          type: :string, required: true, desc: 'git commit hash of initial locales'
   method_option :remove_orphans,         type: :boolean, default: true, desc: 'Remove keys not in the uploaded default locale'
 
+  # Options that mirror the PhraseApp API (https://developers.phrase.com/api/#post-/projects)
+  method_option :autotranslate_check_new_locales,                       type: :boolean, desc: 'Requires autotranslate_enabled to be true'
+  method_option :autotranslate_check_new_translation_keys,              type: :boolean, desc: 'Requires autotranslate_enabled to be true'
+  method_option :autotranslate_check_new_uploads,                       type: :boolean, desc: 'Requires autotranslate_enabled to be true'
+  method_option :autotranslate_enabled,                                 type: :boolean, desc: 'Autopilot, requires machine_translation_enabled.'
+  method_option :autotranslate_mark_as_unverified,                      type: :boolean, desc: 'Requires autotranslate_enabled to be true'
+  method_option :autotranslate_use_machine_translation,                 type: :boolean, desc: 'Requires autotranslate_enabled to be true'
+  method_option :autotranslate_use_translation_memory,                  type: :boolean, desc: 'Requires autotranslate_enabled to be true'
+  method_option :enable_all_data_type_translation_keys_for_translators, type: :boolean, desc: 'Otherwise, translators are not allowed to edit translations other than strings'
+  method_option :enable_icu_message_format,                             type: :boolean, desc: 'We can validate and highlight your ICU messages.'
+  method_option :machine_translation_enabled,                           type: :boolean, desc: 'Enable machine translation support in the project. Required for Pre-Translation'
+  method_option :point_of_contact,                                      type: :string,  desc: 'User ID of the point of contact for the project.'
+  method_option :workflow,                                              type: :string,  desc: 'Review Workflow. "simple" / "review".'
+  method_option :zero_plural_form_enabled,                              type: :boolean, desc: 'Displays the input fields for the \'ZERO\' plural form for every key as well although only some languages require the \'ZERO\' explicitly.'
+
   def setup(locales_path)
     validate_readable_path!('locales', locales_path)
 
     handle_errors do
+      phraseapp_opts = options.slice(
+        :autotranslate_check_new_locales,
+        :autotranslate_check_new_translation_keys,
+        :autotranslate_check_new_uploads,
+        :autotranslate_enabled,
+        :autotranslate_mark_as_unverified,
+        :autotranslate_use_machine_translation,
+        :autotranslate_use_translation_memory,
+        :enable_all_data_type_translation_keys_for_translators,
+        :enable_icu_message_format,
+        :machine_translation_enabled,
+        :point_of_contact,
+        :workflow,
+        :zero_plural_form_enabled)
+
       updater, project_id = PhraseAppUpdater.for_new_project(
                  options[:phraseapp_api_key],
                  options[:phraseapp_project_name],
                  options[:file_format],
                  options[:parent_commit],
-                 verbose: options[:verbose])
+                 verbose: options[:verbose],
+                 **phraseapp_opts)
 
       updater.upload_directory(locales_path, remove_orphans: options[:remove_orphans])
 

--- a/bin/phraseapp_updater
+++ b/bin/phraseapp_updater
@@ -9,6 +9,14 @@ class PhraseAppUpdaterCLI < Thor
   class_option :file_format,    type: :string, default: 'json', desc: 'Filetype of localization files.'
   class_option :verbose,        type: :boolean, default: false, desc: 'Verbose output'
 
+  # Options that mirror the PhraseApp API (https://developers.phrase.com/api/#post-/projects)
+  PHRASEAPP_CREATE_PROJECT_OPTIONS = {
+    zero_plural_form_enabled: {
+      type: :boolean,
+      desc: 'Displays the input fields for the \'ZERO\' plural form for every key as well although only some languages require the \'ZERO\' explicitly.'
+    },
+  }
+
   desc 'setup <locale_path>',
        'Create a new PhraseApp project, initializing it with locale files at <locale_path>. the new project ID is printed to STDOUT'
   method_option :phraseapp_api_key,      type: :string, required: true, desc: 'PhraseApp API key.'
@@ -16,39 +24,15 @@ class PhraseAppUpdaterCLI < Thor
   method_option :parent_commit,          type: :string, required: true, desc: 'git commit hash of initial locales'
   method_option :remove_orphans,         type: :boolean, default: true, desc: 'Remove keys not in the uploaded default locale'
 
-  # Options that mirror the PhraseApp API (https://developers.phrase.com/api/#post-/projects)
-  method_option :autotranslate_check_new_locales,                       type: :boolean, desc: 'Requires autotranslate_enabled to be true'
-  method_option :autotranslate_check_new_translation_keys,              type: :boolean, desc: 'Requires autotranslate_enabled to be true'
-  method_option :autotranslate_check_new_uploads,                       type: :boolean, desc: 'Requires autotranslate_enabled to be true'
-  method_option :autotranslate_enabled,                                 type: :boolean, desc: 'Autopilot, requires machine_translation_enabled.'
-  method_option :autotranslate_mark_as_unverified,                      type: :boolean, desc: 'Requires autotranslate_enabled to be true'
-  method_option :autotranslate_use_machine_translation,                 type: :boolean, desc: 'Requires autotranslate_enabled to be true'
-  method_option :autotranslate_use_translation_memory,                  type: :boolean, desc: 'Requires autotranslate_enabled to be true'
-  method_option :enable_all_data_type_translation_keys_for_translators, type: :boolean, desc: 'Otherwise, translators are not allowed to edit translations other than strings'
-  method_option :enable_icu_message_format,                             type: :boolean, desc: 'We can validate and highlight your ICU messages.'
-  method_option :machine_translation_enabled,                           type: :boolean, desc: 'Enable machine translation support in the project. Required for Pre-Translation'
-  method_option :point_of_contact,                                      type: :string,  desc: 'User ID of the point of contact for the project.'
-  method_option :workflow,                                              type: :string,  desc: 'Review Workflow. "simple" / "review".'
-  method_option :zero_plural_form_enabled,                              type: :boolean, desc: 'Displays the input fields for the \'ZERO\' plural form for every key as well although only some languages require the \'ZERO\' explicitly.'
+  PHRASEAPP_CREATE_PROJECT_OPTIONS.each do |name, params|
+    method_option(name, **params)
+  end
 
   def setup(locales_path)
     validate_readable_path!('locales', locales_path)
 
     handle_errors do
-      phraseapp_opts = options.slice(
-        :autotranslate_check_new_locales,
-        :autotranslate_check_new_translation_keys,
-        :autotranslate_check_new_uploads,
-        :autotranslate_enabled,
-        :autotranslate_mark_as_unverified,
-        :autotranslate_use_machine_translation,
-        :autotranslate_use_translation_memory,
-        :enable_all_data_type_translation_keys_for_translators,
-        :enable_icu_message_format,
-        :machine_translation_enabled,
-        :point_of_contact,
-        :workflow,
-        :zero_plural_form_enabled)
+      phraseapp_opts = options.slice(*PHRASEAPP_CREATE_PROJECT_OPTIONS.keys)
 
       updater, project_id = PhraseAppUpdater.for_new_project(
                  options[:phraseapp_api_key],

--- a/lib/phraseapp_updater.rb
+++ b/lib/phraseapp_updater.rb
@@ -10,9 +10,9 @@ require 'phraseapp_updater/yml_config_loader'
 class PhraseAppUpdater
   using IndexBy
 
-  def self.for_new_project(phraseapp_api_key, phraseapp_project_name, file_format, parent_commit, verbose: false)
+  def self.for_new_project(phraseapp_api_key, phraseapp_project_name, file_format, parent_commit, verbose: false, **phraseapp_opts)
     api = PhraseAppAPI.new(phraseapp_api_key, nil, LocaleFile.class_for_file_format(file_format))
-    project_id = api.create_project(phraseapp_project_name, parent_commit)
+    project_id = api.create_project(phraseapp_project_name, parent_commit, **phraseapp_opts)
     return self.new(phraseapp_api_key, project_id, file_format, verbose: verbose), project_id
   end
 

--- a/lib/phraseapp_updater/phraseapp_api.rb
+++ b/lib/phraseapp_updater/phraseapp_api.rb
@@ -25,10 +25,15 @@ class PhraseAppUpdater
       @locale_file_class = locale_file_class
     end
 
-    def create_project(name, parent_commit)
+    # @param [Hash] opts Options to be passed to the {https://developers.phrase.com/api/#post-/projects PhraseApp API}
+    def create_project(name, parent_commit, **opts)
       params = Phrase::ProjectCreateParameters.new(
-        name: name,
-        main_format: @locale_file_class.phraseapp_type)
+        # Merges name and main_format into opts to prevent overriding these properties
+        opts.merge(
+          name: name,
+          main_format: @locale_file_class.phraseapp_type
+        )
+      )
 
       project = phraseapp_request(Phrase::ProjectsApi, :project_create, params)
 


### PR DESCRIPTION
For whatever reason, phraseapp turns on `zero_plural_form_enabled` by default. This sometimes causes editors to add strings for the zero case even though we don't ever read them for that language. I'd like to turn it off.

This PR adds the ability to setup a phraseapp project and pass an audited subset of options that phraseapp allows to the create project API. There were some I didn't include, like `main_format`, which we already define as `file-format`. Or, things like `enable-branching`, which seem like they would interfere with the purposes of the application.

Presuming this branch gets approved in it's currently incarnation, I would need to update the frontend to include `--zero_plural_form_enabled=false` as an argument. I'd be interested to know if you think I should just make `false` the default value here. Because if I did, I could call it a day. It's dubious whether we want to allow all these options or just gloss over it and cater to our case 🤷  

## API docs

https://developers.phrase.com/api/#post-/projects