### PR TITLE
Bump gem version for phraseapp_updater

### DIFF
--- a/lib/phraseapp_updater/version.rb
+++ b/lib/phraseapp_updater/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class PhraseAppUpdater
-  VERSION = '3.2.0'
+  VERSION = '3.3.0'
 end


### PR DESCRIPTION
This should have been done with the zero-plural-options branch

## Relevant PR

https://github.com/iknow/phraseapp_updater/pull/22